### PR TITLE
Add ability to get lame headers

### DIFF
--- a/src/__tests__/mp3.test.ts
+++ b/src/__tests__/mp3.test.ts
@@ -7,6 +7,8 @@ import { Format } from "wav";
 
 type StereoFormat = Format & { channels: 2 };
 
+const TABLE_OF_CONTENTS_SIZE_BYTES = 100;
+
 let wavData: readonly Float32Array[];
 let smallWavData: readonly Float32Array[];
 let encoder: WasmMediaEncoder<"audio/mpeg">;
@@ -16,6 +18,60 @@ function assertChannelCount(format: Format): asserts format is StereoFormat {
   if (format.channels > 2) {
     throw new Error("too many channels");
   }
+}
+
+function getLameHeader(buffer: Buffer): {
+  frameCount?: number;
+  tableOfContents?: Buffer;
+  headerType?: "Xing" | "Info";
+  position?: number;
+} {
+  const result: {
+    frameCount?: number;
+    tableOfContents?: Buffer;
+    headerType?: "Xing" | "Info";
+    position?: number;
+  } = {};
+
+  for (let i = 0; i < buffer.length; i++) {
+    const fieldName: string = buffer.slice(i, i + 4).toString("utf8");
+    const isVbrMarker = fieldName === "Xing";
+    const isCbrMarker = fieldName === "Info";
+
+    if (isVbrMarker || isCbrMarker) {
+      const headerStart = i;
+      const flags = buffer.readUInt32BE(headerStart + 4);
+      let offset = 8;
+
+      result.headerType = fieldName;
+      result.position = i;
+
+      if (flags & 0x00000001) {
+        result.frameCount = buffer.readUInt32BE(headerStart + offset);
+        offset += 4;
+      }
+
+      if (flags & 0x00000002) {
+        if (
+          headerStart + offset + TABLE_OF_CONTENTS_SIZE_BYTES <=
+          buffer.length
+        ) {
+          result.tableOfContents = Buffer.alloc(TABLE_OF_CONTENTS_SIZE_BYTES);
+          buffer.copy(
+            result.tableOfContents,
+            0,
+            headerStart + offset,
+            headerStart + offset + TABLE_OF_CONTENTS_SIZE_BYTES
+          );
+        }
+        offset += TABLE_OF_CONTENTS_SIZE_BYTES;
+      }
+
+      break;
+    }
+  }
+
+  return result;
 }
 
 beforeAll(async () => {
@@ -110,5 +166,46 @@ test("mono encoding", () => {
   });
   let outBuf = Buffer.from(encoder.encode(smallWavData.slice(0, 1)));
   outBuf = Buffer.concat([outBuf, encoder.finalize()]);
+
+  const headers = getLameHeader(outBuf);
+
+  console.log({ headers });
+
   expect(outBuf).toMatchFile("mono.mp3");
+});
+
+test("cbr header encoding", () => {
+  encoder.configure({
+    channels: format.channels,
+    sampleRate: format.sampleRate,
+    bitrate: 128,
+  });
+  encoder.encode(smallWavData);
+  encoder.finalize();
+  let headerBuf = Buffer.from(encoder.getHeaders());
+
+  const headerInfo = getLameHeader(headerBuf);
+
+  expect(headerInfo.headerType).toBe("Info");
+  expect(headerInfo.frameCount).toBeDefined();
+  expect(headerInfo.frameCount).toBeGreaterThan(0);
+  expect(headerInfo.tableOfContents).toBeDefined();
+});
+
+test("vbr header encoding", () => {
+  encoder.configure({
+    channels: format.channels,
+    sampleRate: format.sampleRate,
+    vbrQuality: 5,
+  });
+  encoder.encode(smallWavData);
+  encoder.finalize();
+  let headerBuf = Buffer.from(encoder.getHeaders());
+
+  const headerInfo = getLameHeader(headerBuf);
+
+  expect(headerInfo.headerType).toBe("Xing");
+  expect(headerInfo.frameCount).toBeDefined();
+  expect(headerInfo.frameCount).toBeGreaterThan(0);
+  expect(headerInfo.tableOfContents).toBeDefined();
 });

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -62,6 +62,15 @@ class WasmMediaEncoder<MimeType extends SupportedMimeTypes> {
     return this.module.getUint8Array(ptr, size);
   }
 
+  private get_headers_buf(size: number) {
+    if (!this.module.enc_get_headers_buf) {
+      return new Uint8Array();
+    }
+
+    const ptr = this.module.enc_get_headers_buf(this.ref);
+    return this.module.getUint8Array(ptr, size);
+  }
+
   private get_common_params(params: BaseEncoderParams) {
     switch (params.channels) {
       case 1:
@@ -177,6 +186,20 @@ class WasmMediaEncoder<MimeType extends SupportedMimeTypes> {
     }
 
     return this.get_out_buf(bytes_written);
+  }
+
+  public getHeaders() {
+    if (!this.module.enc_headers) {
+      return new Uint8Array();
+    }
+
+    const header_size = this.module.enc_headers(this.ref);
+
+    if (header_size === 0) {
+      return new Uint8Array();
+    }
+
+    return this.get_headers_buf(header_size);
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,6 +7,8 @@ type IWasmModuleExports = {
   enc_free(cfg: number): void;
   enc_get_pcm(cfg: number, num_samples: number): number;
   enc_get_out_buf(cfg: number): number;
+  enc_get_headers_buf?: (cfg: number) => number;
+  enc_headers?: (cfg: number) => number;
   version(): number;
   mime_type(): number;
   malloc(size: number): number;

--- a/src/wasm/minify_graph.json
+++ b/src/wasm/minify_graph.json
@@ -4,7 +4,13 @@
   { "name": "enc_flush", "export": "enc_flush", "root": true },
   { "name": "enc_get_pcm", "export": "enc_get_pcm", "root": true },
   { "name": "enc_get_out_buf", "export": "enc_get_out_buf", "root": true },
+  {
+    "name": "enc_get_headers_buf",
+    "export": "enc_get_headers_buf",
+    "root": true
+  },
   { "name": "enc_free", "export": "enc_free", "root": true },
+  { "name": "enc_headers", "export": "enc_headers", "root": true },
   { "name": "version", "export": "version", "root": true },
   { "name": "mime_type", "export": "mime_type", "root": true },
   { "name": "memory", "export": "memory", "root": true },


### PR DESCRIPTION
Firstly, I wanted to say big thank you for the project! It's very well-architected and lightweight 👏 🙇 

I've attempted to add the headers (#7) functionality in a backwards compatible way.

Usage:
```js
let parts = [encoder.encode(data)];
parts.push(encoder.finalize());
// We have to get headers after the encoder is finalized so we generate the correct headers
parts.unshift(encoder.getHeaders()); 

const mp3Size = parts.concat((acc, arr) => acc + arr.length, 0);
const mp3Data = new Uint8Arrray(mp3Size);
mp3Data.set(part[0], 0);
mp3Data.set(part[1], part[0].length);
mp3Data.set(part[2], part[0].length + part[1].length);
```

This would rely on the consumer to decide if they want to generate the headers and add themselves to the output buffer.